### PR TITLE
changed raw topic behaviour

### DIFF
--- a/l3_atom/off_chain/apollox.py
+++ b/l3_atom/off_chain/apollox.py
@@ -6,7 +6,7 @@ class ApolloX(BinanceFutures):
     name = "apollox"
 
     ws_endpoints = {
-        WSEndpoint("wss://fstream.apollox.finance/ws"): ["lob", "ticker", "candle", "trades_l3"]
+        WSEndpoint("wss://fstream.apollox.finance/ws"): ["lob", "ticker", "candle", "trades"]
     }
 
     rest_channels = {

--- a/l3_atom/off_chain/bybit.py
+++ b/l3_atom/off_chain/bybit.py
@@ -30,7 +30,7 @@ class Bybit(OrderBookExchangeFeed):
     @classmethod
     def get_key(cls, msg: dict):
         if 'topic' in msg:
-            return msg['topic'].split('.')[-1].encode()
+            return f'{cls.name}_{msg["topic"].split(".")[-1]}'.encode()
 
     async def subscribe(self, conn: AsyncFeed, feeds: list, symbols):
         args = []

--- a/l3_atom/off_chain/deribit.py
+++ b/l3_atom/off_chain/deribit.py
@@ -26,11 +26,12 @@ class Deribit(OrderBookExchangeFeed):
         if 'params' in msg:
             channel = msg['params']['channel']
             if channel.startswith('chart'):
-                return channel.split('.')[2].encode()
+                key = channel.split('.')[2].encode()
             elif channel.startswith('trade'):
-                return msg['params']['data'][0]['instrument_name'].encode()
+                key = msg['params']['data'][0]['instrument_name'].encode()
             else:
-                return msg['params']['data']['instrument_name'].encode()
+                key = msg['params']['data']['instrument_name'].encode()
+            return f'{cls.name}_{key}'.encode()
 
     def normalise_symbols(self, sym_list: list) -> dict:
         ret = {}

--- a/l3_atom/orderbook_exchange.py
+++ b/l3_atom/orderbook_exchange.py
@@ -236,6 +236,7 @@ class OrderBookExchangeFeed(OrderBookExchange):
                 logging.warning(
                     f"Key field {cls.key_field} not found in message")
                 key = None
+        key = f"{cls.name}_{key}"
         if isinstance(key, str):
             key = key.encode()
         return key
@@ -250,7 +251,7 @@ class OrderBookExchangeFeed(OrderBookExchange):
         logging.info('%s: Starting Kafka Connector', self.name)
         self.kafka_connector = KafkaConnector(self.__class__)
         self.kafka_connector.create_exchange_topics(
-            [*self.ws_channels.keys(), *self.rest_channels.keys(), 'raw'])
+            [*self.ws_channels.keys(), *self.rest_channels.keys()])
         self.kafka_connector.start(loop)
 
     def start(self, loop: asyncio.AbstractEventLoop):

--- a/l3_atom/sink_connector/kafka_multiprocessed.py
+++ b/l3_atom/sink_connector/kafka_multiprocessed.py
@@ -34,7 +34,7 @@ class Kafka(SinkMessageHandler):
         self.kafka_producer = None
         self.admin_client = None
         self.schema_client = None
-        self.topic = f"{self.exchange}_raw"
+        self.topic = f"raw"
 
 
 class KafkaConnector(Kafka):
@@ -101,8 +101,10 @@ class KafkaConnector(Kafka):
             self._admin_init()
         if not self.schema_client:
             self._schema_init()
-        topic_metadata = self.admin_client.list_topics(timeout=5)
         topics = []
+        topic_metadata = self.admin_client.list_topics(timeout=5)
+        if "raw" not in topic_metadata.topics:
+            topics.append(NewTopic("raw", 50, 3))
         schemas = self.schema_client.get_subjects()
         for feed in feeds:
             topic = f'{self.exchange}_{feed}'

--- a/l3_atom/stream_processing/handler.py
+++ b/l3_atom/stream_processing/handler.py
@@ -1,14 +1,36 @@
 from l3_atom.stream_processing.standardisers import standardisers
 import logging
+from typing import AsyncIterable
 
+RAW_TOPIC = 'raw'
+
+handlers = {
+    e.exchange.name: e() for e in standardisers
+}
+
+async def process(stream: AsyncIterable) -> AsyncIterable:
+        """
+        Indefinite iterator over the stream of messages coming in over the raw topic. Continuously iterates and processes each incoming message.
+
+        :param stream: The stream of messages to process
+        :type stream: AsyncIterable
+        :return: Iterator over the stream of raw processed messages
+        :rtype: AsyncIterable
+        """
+        async for key, message in stream.items():
+            key = key.decode()
+            exchange = key.split('_')[0]
+            standardiser = handlers[exchange]
+            if not standardiser.exchange_started:
+                standardiser.start_exchange()
+            await standardiser.handle_message(message)
+            yield message
 
 def initialise_agents(app):
-    """Initialises the Faust agents for each exchange raw topic"""
-    for standardiser in standardisers:
-        agent = standardiser()
-        standardiser.raw_topic = app.topic(agent.raw_topic)
-        logging.info(f"Initialising {agent.id} standardiser")
-        app.agent(standardiser.raw_topic,
-                  name=f"{agent.id}_agent")(agent.process)
-        for k, v in agent.normalised_topics.items():
-            agent.normalised_topics[k] = app.topic(v)
+    """Initialises the Faust agent"""
+    logging.info(f"Initialising raw consumer")
+    for standardiser in handlers.values():
+        for k, topic in standardiser.normalised_topics.items():
+            standardiser.normalised_topics[k] = app.topic(topic)
+    app.agent(RAW_TOPIC)(process)
+

--- a/l3_atom/stream_processing/standardiser.py
+++ b/l3_atom/stream_processing/standardiser.py
@@ -22,12 +22,16 @@ class Standardiser:
 
     def __init__(self) -> None:
         self.id = self.exchange.name
-        self.raw_topic = f'{self.id}_raw'
-        self.exchange = self.exchange()
+        self.raw_topic = f'raw'
+        self.exchange_started = False
         self.feeds = [*self.exchange.ws_channels.keys(), *self.exchange.rest_channels.keys()]
         self.normalised_topics = {
             f"{feed}": f"{self.id}_{feed}" for feed in self.feeds
         }
+
+    def start_exchange(self):
+        self.exchange = self.exchange()
+        self.exchange_started = True
 
     def normalise_symbol(self, exch_symbol: str) -> str:
         """Get the normalised symbol from the exchange symbol"""
@@ -57,16 +61,3 @@ class Standardiser:
         :type msg: dict
         """
         raise NotImplementedError
-
-    async def process(self, stream: AsyncIterable) -> AsyncIterable:
-        """
-        Indefinite iterator over the stream of messages coming in over the raw topic. Continuously iterates and processes each incoming message.
-
-        :param stream: The stream of messages to process
-        :type stream: AsyncIterable
-        :return: Iterator over the stream of raw processed messages
-        :rtype: AsyncIterable
-        """
-        async for message in stream:
-            await self.handle_message(message)
-            yield message

--- a/l3_atom/stream_processing/standardisers/dydx.py
+++ b/l3_atom/stream_processing/standardisers/dydx.py
@@ -10,6 +10,9 @@ class DydxStandardiser(Standardiser):
 
     def __init__(self):
         super().__init__()
+        
+    def start_exchange(self):
+        super().start_exchange()
         self.book_sequences = {
             sym: {} for sym in self.exchange.symbols
         }

--- a/runner.py
+++ b/runner.py
@@ -17,9 +17,11 @@ def main():
 
         from l3_atom.stream_processing import app
 
-        del sys.argv[1]
+        old_args = sys.argv[2:]
+        sys.argv = [sys.argv[0]]
 
         sys.argv.extend(['worker', '-l', 'info'])
+        sys.argv.extend(old_args)
         f_app = app.init()
         f_app.main()
 

--- a/tests/unit/apollox_agent_test.py
+++ b/tests/unit/apollox_agent_test.py
@@ -8,6 +8,7 @@ from l3_atom.stream_processing.standardisers import ApolloXStandardiser
 @pytest.mark.asyncio()
 async def test_binance_futures_agent(mock_kafka):
     exchange = ApolloXStandardiser()
+    exchange.start_exchange()
     for topic in exchange.normalised_topics:
         exchange.normalised_topics[topic] = Mock()
         exchange.normalised_topics[topic].send = AsyncMock()

--- a/tests/unit/binance_agent_test.py
+++ b/tests/unit/binance_agent_test.py
@@ -8,6 +8,7 @@ from l3_atom.stream_processing.standardisers import BinanceStandardiser
 @pytest.mark.asyncio()
 async def test_binance_agent(mock_kafka):
     exchange = BinanceStandardiser()
+    exchange.start_exchange()
     for topic in exchange.normalised_topics:
         exchange.normalised_topics[topic] = Mock()
         exchange.normalised_topics[topic].send = AsyncMock()

--- a/tests/unit/binance_futures_agent_test.py
+++ b/tests/unit/binance_futures_agent_test.py
@@ -8,6 +8,7 @@ from l3_atom.stream_processing.standardisers import BinanceFuturesStandardiser
 @pytest.mark.asyncio()
 async def test_binance_futures_agent(mock_kafka):
     exchange = BinanceFuturesStandardiser()
+    exchange.start_exchange()
     for topic in exchange.normalised_topics:
         exchange.normalised_topics[topic] = Mock()
         exchange.normalised_topics[topic].send = AsyncMock()

--- a/tests/unit/bitfinex_agent_test.py
+++ b/tests/unit/bitfinex_agent_test.py
@@ -8,6 +8,7 @@ from l3_atom.stream_processing.standardisers import BitfinexStandardiser
 @pytest.mark.asyncio()
 async def test_bitfinex_agent(mock_kafka):
     exchange = BitfinexStandardiser()
+    exchange.start_exchange()
     for topic in exchange.normalised_topics:
         exchange.normalised_topics[topic] = Mock()
         exchange.normalised_topics[topic].send = AsyncMock()

--- a/tests/unit/bybit_agent_test.py
+++ b/tests/unit/bybit_agent_test.py
@@ -8,6 +8,7 @@ from l3_atom.stream_processing.standardisers import BybitStandardiser
 @pytest.mark.asyncio()
 async def test_bybit_agent(mock_kafka):
     exchange = BybitStandardiser()
+    exchange.start_exchange()
     for topic in exchange.normalised_topics:
         exchange.normalised_topics[topic] = Mock()
         exchange.normalised_topics[topic].send = AsyncMock()

--- a/tests/unit/coinbase_agent_test.py
+++ b/tests/unit/coinbase_agent_test.py
@@ -8,6 +8,7 @@ from l3_atom.stream_processing.standardisers import CoinbaseStandardiser
 @pytest.mark.asyncio()
 async def test_coinbase_agent(mock_kafka):
     exchange = CoinbaseStandardiser()
+    exchange.start_exchange()
     for topic in exchange.normalised_topics:
         exchange.normalised_topics[topic] = Mock()
         exchange.normalised_topics[topic].send = AsyncMock()

--- a/tests/unit/deribit_agent_test.py
+++ b/tests/unit/deribit_agent_test.py
@@ -8,6 +8,7 @@ from l3_atom.stream_processing.standardisers import DeribitStandardiser
 @pytest.mark.asyncio()
 async def test_deribit_agent(mock_kafka):
     exchange = DeribitStandardiser()
+    exchange.start_exchange()
     for topic in exchange.normalised_topics:
         exchange.normalised_topics[topic] = Mock()
         exchange.normalised_topics[topic].send = AsyncMock()

--- a/tests/unit/dydx_agent_test.py
+++ b/tests/unit/dydx_agent_test.py
@@ -8,6 +8,7 @@ from l3_atom.stream_processing.standardisers import DydxStandardiser
 @pytest.mark.asyncio()
 async def test_dydx_agent(mock_kafka):
     exchange = DydxStandardiser()
+    exchange.start_exchange()
     for topic in exchange.normalised_topics:
         exchange.normalised_topics[topic] = Mock()
         exchange.normalised_topics[topic].send = AsyncMock()

--- a/tests/unit/ftx_agent_test.py
+++ b/tests/unit/ftx_agent_test.py
@@ -8,6 +8,7 @@ from l3_atom.stream_processing.standardisers import FTXStandardiser
 @pytest.mark.asyncio()
 async def test_ftx_agent(mock_kafka):
     exchange = FTXStandardiser()
+    exchange.start_exchange()
     for topic in exchange.normalised_topics:
         exchange.normalised_topics[topic] = Mock()
         exchange.normalised_topics[topic].send = AsyncMock()

--- a/tests/unit/gemini_agent_test.py
+++ b/tests/unit/gemini_agent_test.py
@@ -8,6 +8,7 @@ from l3_atom.stream_processing.standardisers import GeminiStandardiser
 @pytest.mark.asyncio()
 async def test_gemini_agent(mock_kafka):
     exchange = GeminiStandardiser()
+    exchange.start_exchange()
     for topic in exchange.normalised_topics:
         exchange.normalised_topics[topic] = Mock()
         exchange.normalised_topics[topic].send = AsyncMock()

--- a/tests/unit/kafka_test.py
+++ b/tests/unit/kafka_test.py
@@ -38,7 +38,7 @@ def mock_kafka():
     kafka.admin_client = Mock()
     kafka.admin_client.list_topics = Mock()
     kafka.admin_client.list_topics.return_value = MockTopics(
-        ['test_raw', 'test_lob'])
+        ['raw', 'test_lob'])
     kafka.admin_client.create_topics.return_value = {}
     kafka._schema_init()
     kafka.schema_client = Mock()
@@ -57,7 +57,7 @@ def mock_process_message(ret, **kwargs):
 
 @pytest.mark.asyncio()
 async def test_topic_and_schema(mock_kafka):
-    mock_kafka.create_exchange_topics(['raw', 'trades', 'lob'])
+    mock_kafka.create_exchange_topics(['trades', 'lob'])
     mock_kafka.admin_client.create_topics.assert_called_with(
         [kafka_multiprocessed.NewTopic('test_trades', num_partitions=6, replication_factor=1)])
 
@@ -70,6 +70,6 @@ async def test_producer(mock_kafka):
     ret = mock_kafka.producer()
     await ret
     args = mock_kafka.kafka_producer.send.call_args
-    assert args[0][0] == 'test_raw'
+    assert args[0][0] == 'raw'
     assert json.loads(args[0][1].decode())[0] == 4
     mock_kafka.kafka_producer.stop.assert_called()

--- a/tests/unit/kraken_agent_test.py
+++ b/tests/unit/kraken_agent_test.py
@@ -8,6 +8,7 @@ from l3_atom.stream_processing.standardisers import KrakenStandardiser
 @pytest.mark.asyncio()
 async def test_kraken_agent(mock_kafka):
     exchange = KrakenStandardiser()
+    exchange.start_exchange()
     for topic in exchange.normalised_topics:
         exchange.normalised_topics[topic] = Mock()
         exchange.normalised_topics[topic].send = AsyncMock()

--- a/tests/unit/kraken_futures_agent_test.py
+++ b/tests/unit/kraken_futures_agent_test.py
@@ -8,6 +8,7 @@ from l3_atom.stream_processing.standardisers import KrakenFuturesStandardiser
 @pytest.mark.asyncio()
 async def test_kraken_futures_agent(mock_kafka):
     exchange = KrakenFuturesStandardiser()
+    exchange.start_exchange()
     for topic in exchange.normalised_topics:
         exchange.normalised_topics[topic] = Mock()
         exchange.normalised_topics[topic].send = AsyncMock()


### PR DESCRIPTION
Instead of having multiple topics for <exchange>-raw, there is now just one "raw" topic. Multiple benefits:
- Kafka does not handle consumer group rebalancing the way we want when there are multiple topics. It makes it so that each member in the consumer group must subscribe to at least one partition in every topic, which is too much for a single faust Agent to handle
- One topic is easier to manage